### PR TITLE
Update to maintained Clink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # git-autocomplete-for-windows
+
 Enable autocomplete for git commands and branches on Windows command line (cmd).
 
-- Install [Clink](https://mridgers.github.io/clink/)
-- Copy [git-autocomplete.lua](https://github.com/xkmgt/git-autocomplete-for-windows/blob/master/git-autocomplete.lua) into C:\Users\USERNAME\AppData\local\clink
+- Install [Clink](https://chrisant996.github.io/clink/)
+- Copy [git-autocomplete.lua](https://github.com/ztomm/git-autocomplete-for-windows/blob/main/git-autocomplete.lua) into `C:\Users\USERNAME\AppData\local\clink`
 - Restart Windows


### PR DESCRIPTION
The original Clink is not maintained anymore. This PR introduces the link to the maintained fork https://chrisant996.github.io/clink/.

Moreover, @xkmgt is now @ztomm. This PR also reflects that change.